### PR TITLE
Improve error handling for shortcut inspector

### DIFF
--- a/server.js
+++ b/server.js
@@ -200,6 +200,9 @@ app.get("/inspectShortcut", (req, res) => {
         console.log(`${error.code}? How could this happen!`);
         res.send("Error retrieving shortcut");
       });
+  } else {
+    res.status(422);
+    res.send("You must provide a URL to the shortcut you would like to inspect");
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -198,6 +198,8 @@ app.get("/inspectShortcut", (req, res) => {
       })
       .catch(error => {
         console.log(`${error.code}? How could this happen!`);
+      
+        res.status(500);
         res.send("Error retrieving shortcut");
       });
   } else {


### PR DESCRIPTION
This shortcut improves the shortcut inspector functionality by doing the following things:

* When the URL is not provided, the server responds with `422` and a message
* When a shortcut's details couldn't be fetched, the server responds with `500` in addition to the already existing message